### PR TITLE
reliable patching requires #[inline(never)]

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Can patch (almost) any function in Rust (free, associated, instance, generic, et
 ```rust
 extern crate guerrilla;
 
+#[inline(never)]
 fn say_hi(name: &str) {
     println!("hello, {}", name);
 }

--- a/examples/patch.rs
+++ b/examples/patch.rs
@@ -1,5 +1,6 @@
 extern crate guerrilla;
 
+#[inline(never)]
 fn say_hi(name: &str) {
     println!("hello, {}", name);
 }


### PR DESCRIPTION
Before this change, the examples don't work in release mode